### PR TITLE
retry on 500

### DIFF
--- a/md2cf/api.py
+++ b/md2cf/api.py
@@ -50,7 +50,7 @@ class MinimalConfluence:
                 total=4,
                 backoff_factor=1,
                 respect_retry_after_header=True,
-                status_forcelist=[429],
+                status_forcelist=[429, 500],
             )
         )
         self.api.mount("http://", adapter)


### PR DESCRIPTION
Recently, Confluence has been intermittently returning a 500 error, but retrying usually resolves it